### PR TITLE
Make setVisible work on immediate child of a section

### DIFF
--- a/angular-material-sidenav.js
+++ b/angular-material-sidenav.js
@@ -149,6 +149,10 @@
 
                         if (section.children) {
                             section.children.every(function (child) {
+                                if (child.id === id) {
+		                            child.hidden = !value;
+		                            return false;
+		                        };
                                 if (child.pages) {
                                     child.pages.every(function (page) {
                                         if (page.id === id) {


### PR DESCRIPTION
With this small addition, setVisible will work on toggle type elements of the menu as well:

```
ssSideNavSectionsProvider.initWithSections([{
                id: 'toogle_1',
                name: 'Section Heading 1',
                type: 'heading',
                children: [{
                    id: 'toogle_1_baselink',     // <-- You can hide / show this also now
                    name: 'Toogle 1',
                    type: 'toggle',
                    hidden: true,
                    pages: [{
                        id: 'toogle_1_link_1',
                        name: 'item 1',
                        state: 'common.toggle1.item1'
                    }, {
                        id: 'toogle_1_link_2',
                        name: 'item 2',
                        state: 'common.toggle1.item2',
                        hidden: true
                    }, {
                        id: 'toogle_1_link_3',
                        name: 'item 3',
                        state: 'common.toggle1.item3'
                    }]
                }]
            }]);
```
