### PR TITLE
support use type 'link' in section.children and make currentPage more flexible

### DIFF
--- a/angular-material-sidenav.js
+++ b/angular-material-sidenav.js
@@ -139,7 +139,7 @@
                     self.currentPage = page;
                 },
                 isPageSelected: function(page) {
-                    return self.currentPage.state === page;
+                    return self.currentPage ? self.currentPage.state === page : false;
                 },
                 setVisible: function (id, value) {
                     if (!Array.prototype.every) {

--- a/angular-material-sidenav.js
+++ b/angular-material-sidenav.js
@@ -90,7 +90,7 @@
                 }
 
                 self.selectSection(section);
-                self.selectPage(section, page.state);
+                self.selectPage(section, page);
             };
 
             var onStateChangeStart = function(event, toState, toParams) {
@@ -139,7 +139,7 @@
                     self.currentPage = page;
                 },
                 isPageSelected: function(page) {
-                    return self.currentPage === page;
+                    return self.currentPage.state === page;
                 },
                 setVisible: function (id, value) {
                     if (!Array.prototype.every) {

--- a/angular-material-sidenav.js
+++ b/angular-material-sidenav.js
@@ -106,6 +106,8 @@
                                 child.pages.forEach(function(page) {
                                     matchPage(child, page, newState);
                                 });
+                            } else if (child.type === 'link') {
+                                matchPage(child, child, newState);
                             }
                         });
                     } else if (section.pages) {


### PR DESCRIPTION
we can use type 'link' in the lever 2, like this:
`{
          id: 'lever1',
          name: 'lever1',
          type: 'heading',
          children: [
            {
              id: 'lever11',
              name: 'lever11',
              state: 'main.page11',
              type: 'link'
            },
            {
              id: 'lever12',
              name: 'lever12',
              type: 'toggle',
              pages: [
                {
                  id: 'lever121',
                  name: 'lever121',
                  state: 'main.page121'
                },
                {
                  id: 'lever122',
                  name: 'lever122',
                  state: 'main.page122'
                }
              ]
            }
          ]
        }`
