### PR TITLE
Align toggle icon

### DIFF
--- a/angular-material-sidenav.css
+++ b/angular-material-sidenav.css
@@ -108,3 +108,7 @@
     transform: rotate(0deg);
     -webkit-transform: rotate(0deg);
 }
+
+.md-toggle-icon md-icon{
+    height: 40px;
+}


### PR DESCRIPTION
On the toggle, md-icon was with 24px height, while it's parent (.md-toggle-icon) was with 40px, causing it not to be vertically centered on Angular Material ^1.0.5.
